### PR TITLE
Minor fixes from PR comments for user submission

### DIFF
--- a/bin/kotlin-springboot-petstore-server.sh
+++ b/bin/kotlin-springboot-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin-spring -o samples/server/petstore/kotlin-springboot --additional-properties=library=spring-boot"
+ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/petstore/kotlin-springboot --additional-properties=library=spring-boot"
 
 echo "Cleaning previously generated files if any from samples/server/petstore/kotlin-springboot"
 rm -rf samples/server/petstore/kotlin-springboot

--- a/bin/kotlin-springboot-petstore-server.sh
+++ b/bin/kotlin-springboot-petstore-server.sh
@@ -25,7 +25,6 @@ then
   mvn clean package
 fi
 
-# if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/petstore/kotlin-springboot --additional-properties=library=spring-boot"
 

--- a/bin/openapi3/kotlin-springboot-petstore-server.sh
+++ b/bin/openapi3/kotlin-springboot-petstore-server.sh
@@ -25,7 +25,6 @@ then
   mvn clean package
 fi
 
-# if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/openapi3/petstore/kotlin-springboot --additional-properties=library=spring-boot"
 

--- a/bin/openapi3/kotlin-springboot-petstore-server.sh
+++ b/bin/openapi3/kotlin-springboot-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g kotlin-spring -o samples/server/openapi3/petstore/kotlin-springboot --additional-properties=library=spring-boot"
+ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/openapi3/petstore/kotlin-springboot --additional-properties=library=spring-boot"
 
 echo "Cleaning previously generated files if any from samples/server/openapi3/petstore/kotlin-springboot"
 rm -rf samples/server/openapi3/petstore/kotlin-springboot

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -634,21 +634,25 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         // sanitize name
         name = sanitizeName(name, "\\W-[\\$]");
 
-        if (name.toLowerCase().matches("^_*class$"))
+        if (name.toLowerCase().matches("^_*class$")) {
             return "propertyClass";
+        }
 
-        if ("_".equals(name))
+        if ("_".equals(name)) {
             name = "_u";
+        }
 
         // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$"))
+        if (name.matches("^[A-Z_]*$")) {
             return name;
+        }
 
-        if (startsWithTwoUppercaseLetters(name))
+        if (startsWithTwoUppercaseLetters(name)) {
             name = name.substring(0, 2).toLowerCase() + name.substring(2);
+        }
 
         // If name contains special chars -> replace them.
-        if ((((CharSequence) name).chars().anyMatch(character -> specialCharReplacements.keySet().contains("" + ((char) character))))) {
+        if ((name.chars().anyMatch(character -> specialCharReplacements.keySet().contains("" + ((char) character))))) {
             List<String> allowedCharacters = new ArrayList<>();
             allowedCharacters.add("_");
             allowedCharacters.add("$");
@@ -660,8 +664,9 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         name = camelize(name, true);
 
         // for reserved word or word starting with number or containing dollar symbol, escape it
-        if (isReservedWord(name) || name.matches("(^\\d.*)|(.*[$].*)"))
+        if (isReservedWord(name) || name.matches("(^\\d.*)|(.*[$].*)")) {
             name = escapeReservedWord(name);
+        }
 
         return name;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -62,9 +62,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         apiPackage = "org.openapitools.api";
         modelPackage = "org.openapitools.model";
 
-        // spring uses the jackson lib
-        additionalProperties.put("jackson", "true");
-
         addOption(TITLE, "server title name or client service name", title);
         addOption(BASE_PACKAGE, "base package for generated code", basePackage);
         addOption(SERVER_PORT, "configuration the port in which the sever is to run on", serverPort);
@@ -284,6 +281,9 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 (Mustache.Lambda) (fragment, writer) -> writer.write(fragment.execute().replaceAll("\"", Matcher.quoteReplacement("\\\""))));
         additionalProperties.put("lambdaRemoveLineBreak",
                 (Mustache.Lambda) (fragment, writer) -> writer.write(fragment.execute().replaceAll("\\r|\\n", "")));
+
+        // spring uses the jackson lib, and we disallow configuration.
+        additionalProperties.put("jackson", "true");
     }
 
     @Override
@@ -322,19 +322,22 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
 
-        if ("null".equals(property.example))
+        if ("null".equals(property.example)) {
             property.example = null;
+        }
 
         //Add imports for Jackson
         if (!Boolean.TRUE.equals(model.isEnum)) {
             model.imports.add("JsonProperty");
-            if (Boolean.TRUE.equals(model.hasEnums))
+            if (Boolean.TRUE.equals(model.hasEnums)) {
                 model.imports.add("JsonValue");
+            }
 
         } else {
             //Needed imports for Jackson's JsonCreator
-            if (additionalProperties.containsKey("jackson"))
+            if (additionalProperties.containsKey("jackson")) {
                 model.imports.add("JsonCreator");
+            }
         }
 
     }
@@ -371,8 +374,9 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 if (responses != null) {
                     responses.forEach(resp -> {
 
-                        if ("0".equals(resp.code))
+                        if ("0".equals(resp.code)) {
                             resp.code = "200";
+                        }
 
                         doDataTypeAssignment(resp.dataType, new DataTypeAssigner() {
                             @Override

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/README.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/README.mustache
@@ -10,12 +10,12 @@ By default a [`pom.xml`](pom.xml) file will be generated. If you specified `grad
 
 To build the project using maven, run:
 ```bash
-mvn package && java -jar target/openapi-spring-1.0.0.jar
+mvn package && java -jar target/{{artifactId}}-{{artifactVersion}}.jar
 ```
 
 To build the project using gradle, run:
 ```bash
-gradle build && java -jar build/libs/openapi-spring-1.0.0.jar
+gradle build && java -jar build/libs/{{artifactId}}-{{artifactVersion}}.jar
 ```
 
 If all builds successfully, the server should run on [http://localhost:8080/](http://localhost:8080/)


### PR DESCRIPTION
* Puts braces around conditional block bodies with one-liner bodies.
* Modifies README.mustache to use artifact id and version supplied by
user (or default configuration)
* Targets templates under resource directory explicitly to prevent the
need to rebuild for evaluation of  template-only changes.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

